### PR TITLE
Fix repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index",
   "repository": {
     "type": "git",
-    "url": "https://github.com/benadida/node-hkdf"
+    "url": "https://github.com/mozilla/node-hkdf"
   },
   "devDependencies": {
     "vows": "0.5.13"


### PR DESCRIPTION
npm still points to the old repo: https://www.npmjs.org/package/hkdf
