### PR TITLE
Remove unnecessary code

### DIFF
--- a/lib/hkdf.js
+++ b/lib/hkdf.js
@@ -6,13 +6,6 @@
 
 var crypto = require("crypto");
 
-function zeros(length) {
-  var buf = new Buffer(length);
-
-  buf.fill(0);
-
-  return buf.toString();
-}
 // imk is initial keying material
 function HKDF(hashAlg, salt, ikm) {
   this.hashAlg = hashAlg;
@@ -21,7 +14,7 @@ function HKDF(hashAlg, salt, ikm) {
   var hash = crypto.createHash(this.hashAlg);
   this.hashLength = hash.digest().length;
 
-  this.salt = salt || zeros(this.hashLength);
+  this.salt = salt || '';
   this.ikm = ikm;
 
   // now we compute the PRK


### PR DESCRIPTION
According to RFC2104, HMAC keys are automatically padded to the block
length of the compression function with NUL bytes, see page 3:

"append zeros to the end of K to create a B byte string (e.g., if K is
of length 20 bytes and B=64, then K will be appended with 44 zero bytes
0x00)"
